### PR TITLE
feat: add stdout/stderr sockets and no function execution to pyrunfunc

### DIFF
--- a/unicon_backend/evaluator/tasks/programming/security.py
+++ b/unicon_backend/evaluator/tasks/programming/security.py
@@ -82,7 +82,7 @@ def call_function_unsafe(file_name, function, allow_error, *args, **kwargs):
     if not allow_error and err is not None:
         print(json.dumps({"file_name": file_name, "function_name": function_name, "error": str(err)}))
         sys.exit(1)
-    return result, stdout, stderr, err
+    return result, stdout.getvalue(), stderr.getvalue(), err
 """)
 
 

--- a/unicon_backend/evaluator/tasks/programming/security.py
+++ b/unicon_backend/evaluator/tasks/programming/security.py
@@ -62,6 +62,9 @@ def call_function_unsafe(file_name, function_name, allow_error, *args, **kwargs)
         except Exception as e:
             result = None
             err = e
+    if not allow_error and err is not None:
+        print(json.dumps({"file_name": file_name, "function_name": function_name, "error": str(err)}))
+        sys.exit(1)
     return result, stdout, stderr, err
 """)
 

--- a/unicon_backend/evaluator/tasks/programming/security.py
+++ b/unicon_backend/evaluator/tasks/programming/security.py
@@ -24,7 +24,7 @@ def worker(task_queue, result_queue):
             result, stdout, stderr = call_function_from_file(file_name, function_name, *args, **kwargs)
             result_queue.put((result, stdout, stderr, None))
         except Exception as e:
-            result_queue.put((None, e))
+            result_queue.put((None, None, None, e))
 """)
 
 MPI_CLEANUP_TEMPLATE = cst.parse_module("""

--- a/unicon_backend/evaluator/tasks/programming/security.py
+++ b/unicon_backend/evaluator/tasks/programming/security.py
@@ -53,6 +53,16 @@ def call_function_safe(file_name, function_name, allow_error, *args, **kwargs):
         print(json.dumps({"file_name": file_name, "function_name": function_name, "error": str(err)}))
         sys.exit(1)
     return result, stdout, stderr, err
+                                       
+def call_function_unsafe(file_name, function_name, allow_error, *args, **kwargs):
+    with redirect_stdout(io.StringIO()) as stdout, redirect_stderr(io.StringIO()) as stderr: 
+        try:
+            result = function_name(*args, **kwargs)
+            err = None
+        except Exception as e:
+            result = None
+            err = e
+    return result, stdout, stderr, err
 """)
 
 

--- a/unicon_backend/evaluator/tasks/programming/steps.py
+++ b/unicon_backend/evaluator/tasks/programming/steps.py
@@ -326,7 +326,10 @@ class OutputStep(Step[OutputSocket]):
                         cst.Arg(
                             cst.Call(
                                 func=cst.Attribute(value=cst_var("json"), attr=cst_var("dumps")),
-                                args=[cst.Arg(result_dict)],
+                                args=[
+                                    cst.Arg(result_dict),
+                                    cst.Arg(cst_var("str"), keyword=cst_var("default")),
+                                ],
                             )
                         )
                     ],

--- a/unicon_backend/evaluator/tasks/programming/steps.py
+++ b/unicon_backend/evaluator/tasks/programming/steps.py
@@ -525,9 +525,9 @@ class PyRunFunctionStep(Step[PyRunFunctionSocket]):
                     )
                 ],
                 cst.Call(
-                    cst_var("call_function_safe")
+                    cst_var("call_function_unsafe")
                     if module_file.trusted
-                    else cst_var("call_function_unsafe"),
+                    else cst_var("call_function_safe"),
                     [
                         cst.Arg(cst_str(module_name)),
                         cst.Arg(

--- a/unicon_backend/routers/file.py
+++ b/unicon_backend/routers/file.py
@@ -19,7 +19,7 @@ router = APIRouter(prefix="/files", tags=["file"], dependencies=[Depends(get_cur
 
 @router.post("", response_model=str)
 async def create_file(file: UploadFile):
-    return upload_fastapi_file(file)
+    return await upload_fastapi_file(file)
 
 
 @router.get("/{file_id}")

--- a/unicon_backend/routers/problem.py
+++ b/unicon_backend/routers/problem.py
@@ -402,6 +402,7 @@ def get_problem_task_attempt_results(
         .where(TaskAttemptORM.user_id == user.id)
         .options(selectinload(TaskAttemptORM.task_results))
         .options(selectinload(TaskAttemptORM.task))
+        .order_by(col(TaskAttemptORM.id))
     ).all()
 
     db_session.close()


### PR DESCRIPTION
## stdout/stderr

- Added `propagate_stderr`, `propagate_stdout` to pyrunfunctionstep
- `handle_stdout`, `handle_stderr` added to pyrunfunctionsocket
- fix all 3 handle sockets for trusted files (error never worked for trusted)

## no-function execution
- Allowed PyRunFunctionStep to take None as function identifier (aka run file)
- kwargs = injected variables

## bug fixes
- OutputStep should not throw not JSON serializable errors anymore (unless this item cannot even be `__str__`ed)
- fix file upload (missing await)

related to #104 (and closes it once the frontend pr is merged)