### PR TITLE
Support copying tasks, problems, and projects across boundaries

### DIFF
--- a/unicon_backend/dependencies/project.py
+++ b/unicon_backend/dependencies/project.py
@@ -40,17 +40,8 @@ role_permissions["admin"] = role_permissions["helper"] + [
 ]
 
 
-def create_project_with_defaults(
-    create_data: ProjectCreate, organisation_id: int, user: UserORM
-) -> Project:
-    """Note: this function does not add permission tuples (e.g. permify.)
-    Expected to be done outside the function (e.g. after the database commit after this function is called)."""
-    new_project = Project.model_validate(
-        {**create_data.model_dump(), "organisation_id": organisation_id}
-    )
-
-    # Create three default roles
-    new_project.roles = [
+def get_default_project_roles(user: UserORM) -> list[Role]:
+    return [
         Role(
             name="admin",
             users=[user],
@@ -61,6 +52,19 @@ def create_project_with_defaults(
             for role in ["helper", "member"]
         ],
     ]
+
+
+def create_project_with_defaults(
+    create_data: ProjectCreate, organisation_id: int, user: UserORM
+) -> Project:
+    """Note: this function does not add permission tuples (e.g. permify.)
+    Expected to be done outside the function (e.g. after the database commit after this function is called)."""
+    new_project = Project.model_validate(
+        {**create_data.model_dump(), "organisation_id": organisation_id}
+    )
+
+    # Create three default roles
+    new_project.roles = get_default_project_roles(user)
 
     return new_project
 

--- a/unicon_backend/lib/common.py
+++ b/unicon_backend/lib/common.py
@@ -1,7 +1,18 @@
+import copy
+from typing import Any, ClassVar, Generic, TypeVar
+
+from pydantic_core import PydanticUndefined
+from sqlalchemy.orm.session import Session
+from sqlalchemy.sql import select
 from sqlmodel import MetaData, SQLModel
 
+from unicon_backend.database import SessionLocal
+from unicon_backend.lib.helpers import instance_in
 
-class CustomSQLModel(SQLModel):
+_T = TypeVar("_T", bound="CustomSQLModel")
+
+
+class CustomSQLModel(SQLModel, Generic[_T]):
     metadata = MetaData(
         naming_convention={
             "ix": "ix_%(column_0_label)s",
@@ -11,3 +22,84 @@ class CustomSQLModel(SQLModel):
             "pk": "pk_%(table_name)s",
         }
     )
+
+    excluded_fields_on_copy: ClassVar[list[str]] = []
+
+    def excluded_on_copy(self) -> bool:
+        return False
+
+    def shallow_copy(self: _T) -> _T:
+        data = {}
+        for name, info in self.model_fields.items():
+            value = getattr(self, name)
+            if (
+                getattr(info, "primary_key", PydanticUndefined) != PydanticUndefined
+                or getattr(info, "foreign_key", PydanticUndefined) != PydanticUndefined
+                or name in self.excluded_fields_on_copy
+            ):
+                continue
+            data[name] = copy.copy(value)
+        return self.__class__(**data)
+
+    def deep_copy(self: _T, excluded_classes: list[Any] | None = None) -> _T:
+        excluded_classes = excluded_classes or []
+        child_excluded_classes = excluded_classes + [self.__class__]  # avoid infinite recursion
+
+        copied = self.shallow_copy()
+
+        def _allowed_to_copy(value):
+            return not instance_in(value, excluded_classes) and not value.excluded_on_copy()
+
+        for name in self.__sqlmodel_relationships__:
+            value = getattr(self, name)
+
+            if name in self.excluded_fields_on_copy:
+                continue
+
+            if isinstance(value, CustomSQLModel) and _allowed_to_copy(value):
+                setattr(copied, name, value.deep_copy(excluded_classes=child_excluded_classes))
+
+            elif isinstance(value, list):
+                children = []
+                for item in value:
+                    if not _allowed_to_copy(item):
+                        continue
+                    if isinstance(item, CustomSQLModel):
+                        child = item.deep_copy(excluded_classes=child_excluded_classes)
+                    else:
+                        child = copy.deepcopy(item)
+                    children.append(child)
+                setattr(copied, name, children)
+
+        return copied
+
+    @classmethod
+    def get_by_pk(cls: type[_T], id: int | dict[str, int], db_session: Session | None = None) -> _T:
+        pk_fields = [
+            name
+            for name, field in cls.model_fields.items()
+            if getattr(field, "primary_key", PydanticUndefined) != PydanticUndefined
+        ]
+
+        if len(pk_fields) == 1:
+            conditions = [getattr(cls, pk_fields[0]) == id]
+        else:
+            if not isinstance(id, dict):
+                raise ValueError(f"Composite primary key requires dict, got {type(id)}")
+
+            if set(id.keys()) != set(pk_fields):
+                raise ValueError(f"Invalid primary keys. Required: {list(pk_fields)}")
+
+            conditions = [getattr(cls, name) == id[name] for name in pk_fields]
+
+        def _get_model_by_pk(db_session: Session) -> _T:
+            result = db_session.scalar(select(cls).where(*conditions))
+            if result is None:
+                raise ValueError(f"{cls.__name__} with id {id} not found")
+            return result
+
+        if db_session is not None:
+            return _get_model_by_pk(db_session)
+
+        with SessionLocal() as db_session:
+            return _get_model_by_pk(db_session)

--- a/unicon_backend/lib/helpers.py
+++ b/unicon_backend/lib/helpers.py
@@ -20,3 +20,7 @@ def create_multi_index[T, K, V](
     for item in filter(filter_fn, items):
         index[key_fn(item)].append(value_fn(item))
     return index
+
+
+def instance_in(instance, classes):
+    return any([isinstance(instance, classes) for classes in classes])

--- a/unicon_backend/models/organisation.py
+++ b/unicon_backend/models/organisation.py
@@ -1,6 +1,6 @@
 import uuid
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 import sqlalchemy as sa
 import sqlalchemy.dialects.postgresql as pg
@@ -34,6 +34,8 @@ class Organisation(OrganisationBase, table=True):
     invitation_keys: sa_orm.Mapped[list["OrganisationInvitationKey"]] = Relationship(
         back_populates="organisation", cascade_delete=True
     )
+
+    excluded_fields_on_copy: ClassVar[list[str]] = ["members", "invitation_keys"]
 
 
 class OrganisationRole(StrEnum):
@@ -83,6 +85,8 @@ class Project(ProjectBase, table=True):
     groups: sa_orm.Mapped[list["Group"]] = Relationship(
         back_populates="project", cascade_delete=True
     )
+
+    excluded_fields_on_copy: ClassVar[list[str]] = ["organisation", "roles", "groups"]
 
 
 class Group(CustomSQLModel, table=True):


### PR DESCRIPTION
- Allow copying tasks to any problem, regardless of project
- Allow copying problems to any project, across organizations
- Allow copying projects across organizations
- Add shallow_copy, deep_copy, get_by_pk to CustomSQLModel
- Update task, problem, project, organization models to support copying
- Auto-insert id and order_index in TaskORM
- Refactor task addition/update to use auto-inserted values